### PR TITLE
added error message when attempting to save duplicate file names

### DIFF
--- a/geist/pyplot.py
+++ b/geist/pyplot.py
@@ -9,7 +9,10 @@ class Viewer(object):
         self._gui = gui
         self._repo = repo
 
-    def save(self, name):
+    def save(self, name, force=False):
+        if name in self._repo.entries and force==False:
+            raise KeyError(
+                name + ' already exists, to overwrite, pass force=True')
         self._repo[name] = self.visible()
 
     def visible(self):


### PR DESCRIPTION
When attempting to save an image under a pre-existing name, will throw error to check user wants to do this.
