### PR TITLE
Take arguments to the X backends create_process

### DIFF
--- a/geist/backends/_x11_common.py
+++ b/geist/backends/_x11_common.py
@@ -51,11 +51,12 @@ class GeistXBase(object):
     def display(self):
         return self._display
 
-    def create_process(self, command, shell=True, stdout=None, stderr=None):
+    def create_process(self, command, shell=True, stdout=None, stderr=None,
+                       env=None):
         """
         Execute a process using subprocess.Popen, setting the backend's DISPLAY
         """
-        env = kwargs.pop('env', dict(os.environ))
+        env = env if env is not None else dict(os.environ)
         env['DISPLAY'] = self.display
         return subprocess.Popen(command, shell=shell,
                                 stdout=stdout, stderr=stderr,


### PR DESCRIPTION
To allow greater control over creating processes in X, pass key word args through to Popen.

Also, default to not redirecting stdout & stderr so errors are more visible.
